### PR TITLE
web3 modal improvements

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -2038,3 +2038,7 @@ scrollbar-width: none;  /* Firefox */
 .max-w-100vw {
 max-width: 100vw;
 }
+
+.guTiyV {
+  z-index: 100;
+} 


### PR DESCRIPTION
##### Description
Increased z-index value on the web3modal. This solves the bug that caused the chart pointer going over the modal, making impossible to click on the web3 options.

Before
<img width="970" alt="Screenshot 2021-03-01 at 10 32 19" src="https://user-images.githubusercontent.com/10923247/109478351-6c355c80-7a79-11eb-9745-340945005aa5.png">


After
<img width="976" alt="Screenshot 2021-03-01 at 10 31 27" src="https://user-images.githubusercontent.com/10923247/109478299-57f15f80-7a79-11eb-932e-f2569305c9f5.png">

