### PR TITLE
Show percentage of staking on farm pools

### DIFF
--- a/src/pages/StakingPageSingle.svelte
+++ b/src/pages/StakingPageSingle.svelte
@@ -74,6 +74,10 @@
       return Number(formatEther(amount)).toFixed();
     };
 
+    const percentAmount = (amount1, amount2, fixed) => {
+      return Number(+amount1 / +amount2 * 100).toFixed(fixed);
+    }
+
     onMount(() => {
       stakingPool = stakingPools.find((item) => {
         if(item.slug === slug) {
@@ -479,7 +483,7 @@ metadata={{
               <p>There are total : <strong>{Number(formatEther(data.totalDeposited)).toFixed(4)} {stakingPool.stakingTokenSymbol} </strong> staked in the Staking contract.</p>
               <p>Staked by you: <strong>{Number(formatEther(data.userDeposited)).toFixed(4)} {stakingPool.stakingTokenSymbol}</p>
               <p>
-                You are staking : <strong>{data.userDeposited.eq(0) ? "0" : formatEther(data.userDeposited.div(data.totalDeposited).mul(100))}%</strong>
+                You are staking : <strong>{data.userDeposited.eq(0) ? "0" : percentAmount(data.userDeposited, data.totalDeposited, 4)}%</strong>
               </p>
               {#if data.exitFeePercentage.gt(0)}
                   <p>


### PR DESCRIPTION
##### Description
As a USER I want to see how much percentage of the pool I am staking.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] Changes don't break existing behavior
- [X] Test coverage hasn't decreased

##### Testing
It is correctly showing how much % of staking I have on DOUGH/ETH Sushi Pool with a fixed of 4 decimals (didn't test other pools)

