### PR TITLE
replacing vedough token image urls

### DIFF
--- a/src/config/images.json
+++ b/src/config/images.json
@@ -136,10 +136,10 @@
   "simulator_chart": "https://raw.githubusercontent.com/pie-dao/brand/master/misc/chart.png",
   "simulator_sword": "https://raw.githubusercontent.com/pie-dao/brand/master/misc/sword.png",
   "simulator_launch": "https://raw.githubusercontent.com/pie-dao/brand/master/misc/launch.png",
-  "simulator_veDough": "https://raw.githubusercontent.com/pie-dao/brand/master/PIE%20Tokens/veDOUGH.png",
+  "simulator_veDough": "https://raw.githubusercontent.com/pie-dao/brand/master/DOUGH%20Token/veDOUGH.png",
   "simulator_info": "https://raw.githubusercontent.com/pie-dao/brand/master/misc/info.svg",
   "simulator_customize": "https://raw.githubusercontent.com/pie-dao/brand/master/misc/customize.svg",
-  "veDough": "https://raw.githubusercontent.com/pie-dao/brand/6adcf8b3a75380cc49ea119150b683a031afa016/PIE%20Tokens/veDOUGH.svg",
+  "veDough": "https://raw.githubusercontent.com/pie-dao/brand/fa037b10556371316c43ea0f0939fd35897f8443/DOUGH%20Token/veDOUGH.svg",
   "rewardsPie": "https://raw.githubusercontent.com/pie-dao/brand/6adcf8b3a75380cc49ea119150b683a031afa016/PIE%20Tokens/RewardPie.svg"
 
 }


### PR DESCRIPTION
the url changed because of moving the images to its relevant folder on the brand repo

##### Description
<!-- A description on what this PR aims to solve. -->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Linter status: 100% pass
- [ ] Changes don't break existing behavior
- [ ] Test coverage hasn't decreased

##### Testing
<!-- Why should the PR reviewer trust that this change doesn't break
  anything? How have you tested this change?
-->

##### Refers/Fixes
<!--
  Link to an issue if applicable. For example:
  If your PR fixes an issue -- Fixes: #102
  If your PR refers an issue -- Refs: #101
-->
