### PR TITLE
PIE-627 Add Compounding manual on /#/Learn

### DIFF
--- a/src/pages/Learn.svelte
+++ b/src/pages/Learn.svelte
@@ -72,7 +72,17 @@
       </div>
       <div class="text-left font-bold text-lg px-6 leading-7 mb-4">What are PieVaults?</div>
       <div class="text-justify font-thin h-120px text-ellipsis overflow-hidden px-6 leading-6 mb-4">
-        PieVaults are the DAO’s latest product range, unlocking active yield-generating strategies for each underlying asset in the index. Lending, native staking, and meta-governance are all possible. Yearn Ecosystem Pie ( $YPIE) is the first PieVault, giving complete exposure to the Yearn Finance ecosystem.      </a>
+        PieVaults are the DAO’s latest product range, unlocking active yield-generating strategies for each underlying asset in the index. Lending, native staking, and meta-governance are all possible with them.</a>
+    </div>
+      
+    <div class="flex flex-col w-100pc thinborder hover:border-pink md:w-31pc md:min-w-280px  h-420px bg-white rounded my-2 mx-2 md:my-1pc md:mx-1pc">
+      <a class="" target="_blank" href={`https://gateway.pinata.cloud/ipfs/QmT51shK96o2kNJW4PweZSc7xCY1UrcBgzB9FE6PVTKdgp`}>
+      <div class="w-100pc min-w-100pc h-200px flex items-start justify-end mb-4 rounded" style="background: url(https://miro.medium.com/max/1400/1*KABX967U0nJRoD3y5JLF4g.png) no-repeat center center; background-size: cover!important;">
+        <div class="text-right mt-4 mr-4"><span class="text-xs font-bold text-white bg-black roundedxs px-2 py-1">Slice</span></div>
+      </div>
+      <div class="text-left font-bold text-lg px-6 leading-7 mb-4"SLICE Compounding</div>
+      <div class="text-justify font-thin h-120px text-ellipsis overflow-hidden px-6 leading-6 mb-4">
+        veDough holders have the option to compound their earned SLICE into more veDough just by transfering the claimed SLICE tokens. Interested? Deep dive into the details here.</a>
     </div>
 
 


### PR DESCRIPTION
##### Description
**Added an element to educate about SLICE COMPOUNDING at the Learn About PieDAO**, in the last position. URL and content are, in my opinion ok. Missing an image to represent the compounding process from Slice to veDough.

**Additionally, trimmed the 'What are PieVaults' description to fit the element** as follows:
from: PieVaults are the DAO’s latest product range, unlocking active yield-generating strategies for each underlying asset in the index. Lending, native staking, and meta-governance are all possible. Yearn Ecosystem Pie ($YPIE) is the first PieVault, giving complete exposure to the Yearn Finance ecosystem.
To: PieVaults are the DAO’s latest product range, unlocking active yield-generating strategies for each underlying asset in the index. Lending, native staking, and meta-governance are all possible with them.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Linter status: 100% pass
- [ ] Changes don't break existing behavior
- [ ] Test coverage hasn't decreased

##### Testing
Check the content is correctly alinged
Check there are no typos
Check the link works (to open https://gateway.pinata.cloud/ipfs/QmT51shK96o2kNJW4PweZSc7xCY1UrcBgzB9FE6PVTKdgp )
Check the copy fits
Check the image is in place

##### Refers/Fixes
<!--
  Link to an issue if applicable. For example:
  If your PR fixes an issue -- Fixes: #102
  If your PR refers an issue -- Refs: #101
-->
