### PR TITLE
Legacy Farm pools target updated

### DIFF
--- a/src/pages/LPStakingV2.svelte
+++ b/src/pages/LPStakingV2.svelte
@@ -217,7 +217,7 @@
               </div>
             </div>
             <div class="text-center font-thin w-100pc mt-4 hover:opacity-60">
-              <a href="#/lp-legacy-farm">Cannot find your pool? <strong>Go to old farms!</strong></a>
+              <a href="https://legacy.piedao.org/#/lp-legacy-farm">Cannot find your pool? <strong>Go to old farms!</strong></a>
             </div>
             <div class="text-center font-thin w-100pc mt-4 hover:opacity-60">
               <a href="https://vfat.tools/piedao/" target="_blank">Looking for APR? <strong>Go to 👨‍🌾 vfat.tools!</strong></a>


### PR DESCRIPTION
The piedao.org site's Legacy farm link is broken. This change expects to change the target URL to send the user to the PieDAO Legacy site if the user is interested into surfing legacy information.

##### Description
Updated the href for the following link at /#/farms
![image](https://user-images.githubusercontent.com/87126850/157049542-d334d72f-542e-48d7-8695-a19bdf9ccbca.png)


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Linter status: 100% pass
- [ ] Changes don't break existing behavior
- [ ] Test coverage hasn't decreased

##### Testing
Open piedao.org
Go to /#/farms
Click on: Cannot find your pool? Go to old farms!
Consider the test successfull if redirected to https://legacy.piedao.org/#/lp-legacy-farm

##### Refers/Fixes
<!--
  Link to an issue if applicable. For example:
  If your PR fixes an issue -- Fixes: #102
  If your PR refers an issue -- Refs: #101
-->
