### PR TITLE
remove get store inside getPoolsUser

### DIFF
--- a/src/pages/Piefolio.svelte
+++ b/src/pages/Piefolio.svelte
@@ -181,8 +181,7 @@
   }
 
   const getPoolsUser = async () => {
-      const { provider, signer } = get(eth);
-      const stakingContract = new ethers.Contract(smartcontracts.stakingPools, stakingPoolsABI,  signer || provider);
+      const stakingContract = new ethers.Contract(smartcontracts.stakingPools, stakingPoolsABI,  $eth.signer || $eth.provider);
       let pools = await stakingContract.getPools($eth.address);
       const res = [];
       


### PR DESCRIPTION
##### Description
Removed get eth from store since it is already available inside as a reactive value in order to prevent signer / provider from being undefined