### PR TITLE
fix to prevent issues with casting BN string to scientific notation

### DIFF
--- a/src/components/JoinSwapExternAmount.svelte
+++ b/src/components/JoinSwapExternAmount.svelte
@@ -251,7 +251,8 @@
   }
 
   async function swap() {
-    
+    // fix issues with BN casting scientific notation
+    BigNumber.set({ EXPONENTIAL_AT: 99 });
     try {
       if (!quote || Object.entries(quote).length === 0) {
         error = 'You need a quote first.';


### PR DESCRIPTION
Multiple BigNumber libraries are in place on the website.

BigNumber.js will convert numbers of a certain length to strings with scientific notation:

'1030356934929320413041020120' => '1.03e21' 

This creates an error when ethers attempts to parse the string.