### PR TITLE
Removing outdated incentives information

### DIFF
--- a/src/pages/landings/oven.svelte
+++ b/src/pages/landings/oven.svelte
@@ -279,7 +279,7 @@ Once both conditions are met Oven will jump into action, baking everyones’ pie
 <Accordion class="flex flex-col">
   <button class="accordionbutton flex flex-col" slot="header" let:toggle on:click={toggle}>Is there a time limit to withdraw my pie?</button>
   <div class="accordioncontent">
-    None at all! But don’t forget, the sooner you withdraw your pie the sooner you can put it to work in our farms. We’re incentivizing pie liquidity providers with 150k of delicious DOUGH each week. <a class="font-bold" about="_blank" href="https://pools.piedao.org/#/lp-legacy-farm">Check it out</a>.
+    None at all! But don’t forget, the sooner you withdraw your pie the sooner you can put it to work in our farms.
   </div>
 </Accordion>
 


### PR DESCRIPTION
Removing text that stated there were incentives for Oven liquidity providers, as it is outdated

##### Description
<!-- A description on what this PR aims to solve. -->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Linter status: 100% pass
- [ ] Changes don't break existing behavior
- [ ] Test coverage hasn't decreased

##### Testing
<!-- Why should the PR reviewer trust that this change doesn't break
  anything? How have you tested this change?
-->

##### Refers/Fixes
<!--
  Link to an issue if applicable. For example:
  If your PR fixes an issue -- Fixes: #102
  If your PR refers an issue -- Refs: #101
-->
