### PR TITLE
hardcoded decimals for default coins on swap in case user is not logg…

### DIFF
--- a/src/components/piefolio/Exchange.svelte
+++ b/src/components/piefolio/Exchange.svelte
@@ -1,6 +1,6 @@
 <script>
   import images from "../../config/images.json";
-  import { Timeout, quoteRefreshSeconds } from '../../classes/Timer.js';
+  import { Timeout } from '../../classes/Timer.js';
   import { _ } from "svelte-i18n";
   import debounce from "lodash/debounce";
   import BigNumber from "bignumber.js";
@@ -32,28 +32,34 @@
   } from "../../components/helpers";
 
   const ZeroEx = '0xdef1c0ded9bec7f1a1670819833240f027b25eff';
-  $: listed = [
+  const baseListed = [
     {
       address: '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
       symbol: 'ETH',
-      icon: getTokenImage('eth')
+      icon: getTokenImage('eth'),
+      decimals: 18
     },
     {
       address: '0xad32A8e6220741182940c5aBF610bDE99E737b2D',
       symbol: 'DOUGH',
-      icon: getTokenImage('0xad32A8e6220741182940c5aBF610bDE99E737b2D')
+      icon: getTokenImage('0xad32A8e6220741182940c5aBF610bDE99E737b2D'),
+      decimals: 18
     },
     {
       address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
       symbol: 'USDC',
-      icon: getTokenImage('0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48')
+      icon: getTokenImage('0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'),
+      decimals: 6
     },
     {
       address: '0x33e18a092a93ff21ad04746c7da12e35d34dc7c4',
       symbol: 'PLAY',
-      icon: getTokenImage('0x33e18a092a93ff21ad04746c7da12e35d34dc7c4')
+      icon: getTokenImage('0x33e18a092a93ff21ad04746c7da12e35d34dc7c4'),
+      decimals: 18
     },
   ];
+
+  $: listed = baseListed;
 
   let modal;
   let modalOption = {
@@ -65,19 +71,9 @@
   let targetModal = 'sell';
   let timeout;
   
+  let defaultTokenSell = baseListed.find(l => l.symbol === 'ETH');
+  let defaultTokenBuy = baseListed.find(l => l.symbol === 'DOUGH');
 
-  let defaultTokenSell = {
-    address: '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
-    symbol: 'ETH',
-    icon: getTokenImage('eth')
-  }
-
-  let defaultTokenBuy = {
-    address: '0xad32A8e6220741182940c5aBF610bDE99E737b2D',
-    symbol: 'DOUGH',
-    icon: getTokenImage('0xad32A8e6220741182940c5aBF610bDE99E737b2D')
-  };
-  
   const defaultAmount = {
     bn: new BigNumber(0),
     label: 0
@@ -144,7 +140,6 @@
 
   onMount(async () => {
     isLoading = true;
-    console.log('onMount')
     setupListedToken();
 
     if($eth.address) {

--- a/src/pages/Tokensswap.svelte
+++ b/src/pages/Tokensswap.svelte
@@ -31,23 +31,30 @@
   } from "../components/helpers";
 
   const ZeroEx = '0xdef1c0ded9bec7f1a1670819833240f027b25eff';
-  $: listed = [
+
+  // will return undefined in first render if assigned to reactive variable
+  const baseListed = [
     {
       address: '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
       symbol: 'ETH',
-      icon: getTokenImage('eth')
+      icon: getTokenImage('eth'),
+      decimals: 18
     },
     {
       address: '0xad32A8e6220741182940c5aBF610bDE99E737b2D',
       symbol: 'DOUGH',
-      icon: getTokenImage('0xad32A8e6220741182940c5aBF610bDE99E737b2D')
+      icon: getTokenImage('0xad32A8e6220741182940c5aBF610bDE99E737b2D'),
+      decimals: 18
     },
     {
       address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
       symbol: 'USDC',
-      icon: getTokenImage('0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48')
+      icon: getTokenImage('0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'),
+      decimals: 6
     }
   ];
+
+  $: listed = baseListed;
 
   let modal;
   let modalOption = {
@@ -59,18 +66,8 @@
   let targetModal = 'sell';
   let timeout;
   
-
-  let defaultTokenSell = {
-    address: '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
-    symbol: 'ETH',
-    icon: getTokenImage('eth')
-  }
-
-  let defaultTokenBuy = {
-    address: '0xad32A8e6220741182940c5aBF610bDE99E737b2D',
-    symbol: 'DOUGH',
-    icon: getTokenImage('0xad32A8e6220741182940c5aBF610bDE99E737b2D')
-  };
+  let defaultTokenSell = baseListed.find(l => l.symbol === 'ETH');
+  let defaultTokenBuy = baseListed.find(l => l.symbol === 'DOUGH');
 
   const defaultAmount = {
     bn: new BigNumber(0),
@@ -138,7 +135,6 @@
 
   onMount(async () => {
     isLoading = true;
-    console.log('onMount')
     setupListedToken();
 
     if($eth.address) {


### PR DESCRIPTION
USDC has 6 decimals, as opposed to 18 for PLAY, DOUGH, DEFI++ and ETH. This causes issues in the exchange modal when the user is not signed in because:

- The application assumes 18 decimals unless it is overriden
- The override happens when the user is connected

A simple fix to this issue is included in this PR - the base tokens are initialised with a decimals field, so that when USDC is selected without being connected to a provider, for any reason, we have the correct decimals