### PR TITLE
Fix/dead links

### DIFF
--- a/src/config/links.json
+++ b/src/config/links.json
@@ -1,6 +1,6 @@
 {
   "audit": "https://github.com/pie-dao/audits",
-  "dao": "https://aragon.in/piedao",
+  "dao": "https://client.aragon.org/#/piedao",
   "discord": "http://discord.link/PieDAO",
   "docs": "https://docs.piedao.org",
   "forum": "https://forum.piedao.org",

--- a/src/config/pools.json
+++ b/src/config/pools.json
@@ -153,6 +153,7 @@
     "streamingFees": "0",
     "useMintOverBuy": false,
     "buyButton": true,
+    "buyUrl": "https://app.balancer.fi/#/trade/ether/0x8d1ce361eb68e9e05573443c407d4a3bed23b033",
     "swapEnabled": false,
     "coingeckoId": "piedao-defi",
     "swapFees": "1",

--- a/src/pages/landings/Marketing.svelte
+++ b/src/pages/landings/Marketing.svelte
@@ -12,7 +12,7 @@
   import AuditedBy from '../../components/AuditedBy.svelte';
   import Newsletter from '../../components/Newsletter.svelte';
   import { LottiePlayer } from '@lottiefiles/svelte-lottie-player';
-  import { farming } from '../../stores/eth/writables.js';
+  import { farming, stakingStats } from '../../stores/eth/writables.js';
   import { getTokenImage, formatFiat } from '../../components/helpers.js';
   import { fade } from 'svelte/transition';
   import HowTo from '../../components/HowToGovernance.svelte';
@@ -193,7 +193,7 @@
     </div>
     <div class="min-w-150px flex flex-col items-center leading-5 mt-12">
       <img class="h-50px inline mb-4" src={images.finger_point} alt="finger point" /><span
-        >Over 480<br />stakeholders</span
+        >Over {Math.floor($stakingStats.totalHolders / 10) * 10}<br />stakeholders</span
       >
     </div>
     <div class="min-w-150px flex flex-col items-center leading-5 mt-12">


### PR DESCRIPTION
- Replaced aragon link to https://client.aragon.org/#?/piedao
- Added a `buyUrl` for DEFI++ config which links directly to the balancer pool automagically 
- Used the staking stats with floor rounding to keep the `Over X addresses` consistent